### PR TITLE
titleタグの重複の削除

### DIFF
--- a/src/components/head.tsx
+++ b/src/components/head.tsx
@@ -1,0 +1,30 @@
+import { FC } from "react";
+
+type MetaData = {
+  title: string;
+  description: string;
+  icon: string;
+};
+
+const DEFAULT_META_DATA: MetaData = {
+  title: "React Tokyo",
+  description: "A React community in Tokyo",
+  icon: "/images/favicon.png",
+};
+
+/**
+ * ページのメタデータ設定用のコンポーネント
+ */
+export const Head: FC<Partial<MetaData>> = (metaProps) => {
+  const meta: MetaData = {
+    ...DEFAULT_META_DATA,
+    ...metaProps,
+  };
+  return (
+    <>
+      <title>{meta.title}</title>
+      <meta name="description" content={meta.description} />
+      <link rel="icon" type="image/png" href={meta.icon} />
+    </>
+  );
+};

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -7,18 +7,9 @@ import { Footer } from '../components/footer';
 
 type RootLayoutProps = { children: ReactNode };
 
-const meta = {
-  title: 'React Tokyo',
-  description: 'A React community in Tokyo',
-  icon: '/images/favicon.png',
-};
-
 export default async function RootLayout({ children }: RootLayoutProps) {
   return (
     <div className="font-['Nunito']">
-      <title>{meta.title}</title>
-      <meta name="description" content={meta.description} />
-      <link rel="icon" type="image/png" href={meta.icon} />
       <Header />
       <main className="m-6 flex items-center justify-center *:min-h-64 *:min-w-64 lg:m-0 lg:min-h-svh">
         {children}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,10 @@
+import { Head } from '../components/head';
 import { JoinDiscordServer } from '../components/joinDiscordServer';
-
-const meta = {
-  title: 'React Tokyo',
-};
 
 export default async function HomePage() {
   return (
     <div>
-      <title>{meta.title}</title>
+      <Head title='React Tokyo' />
       <div className="grid grid-rows-3 lg:grid-cols-3 lg:grid-flow-row gap-y-2 gap-x-8">
         <div className="lg:col-span-2 flex flex-col items-start justify-center">
           <h1 className="text-4xl font-bold tracking-tight">We are React Tokyo Community</h1>


### PR DESCRIPTION
# 内容

https://github.com/react-tokyo/tasks/issues/12 のIssueを対応しました。

# 修正方針

src/pages/_layout.tsx と src/pages/index.tsx でtitleタグの指定が重複していたので、その点を整理しています。
「このページだけdescriptionを変えたい」などもあるかもしれないと思い、
src/components/head.tsx でデフォルト値含めて管理する想定にしました。

# その他

フォークからプルリクエストを作るのが初なので、
変な設定がありましたらご指摘お願いします！