### PR TITLE
docs: replace catchphrase and update description text

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,19 +16,19 @@ export default async function HomePage() {
   return (
     <div>
       <title>{meta.title}</title>
-      <div className="grid grid-rows-3 lg:grid-cols-3 lg:grid-flow-row gap-y-2 gap-x-8">
-        <div className="lg:col-span-2 flex flex-col items-start justify-center">
-          <h1 className="text-4xl font-bold tracking-tight">分からないを分かち合う、広げようReactの世界。</h1>
-        </div>
-        <div className="lg:row-span-3 flex items-center justify-center">
+      <div className="grid grid-rows-[auto_auto_auto] lg:grid-cols-3 lg:grid-flow-row gap-y-2 gap-x-8">
+        <div className="order-1 lg:order-2 lg:row-span-3 flex items-center justify-center">
           <div className="w-40 lg:w-80 rounded-full bg-[#F45554]">
             <img src="/images/react-tokyo-logo.png" alt="react tokyo logo" />
           </div>
         </div>
-        <div className="lg:row-span-2 lg:col-span-2 flex flex-col items-start justify-center gap-8">
+        <div className="order-2 lg:order-1 lg:col-span-2 flex flex-col items-start justify-center py-6">
+          <h1 className="text-4xl font-bold tracking-tight">分からないを分かち合う、広げようReactの世界。</h1>
+        </div>
+        <div className="order-3 lg:row-span-2 lg:col-span-2 flex flex-col items-start justify-center gap-8">
           <div>
-            {descriptions.map((description) => (
-              <p>{description}</p>
+            {descriptions.map((description, index) => (
+              <p key={index}>{description}</p>
             ))}
           </div>
           <div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,13 +4,21 @@ const meta = {
   title: 'React Tokyo',
 };
 
+const descriptions = [
+  '東京を中心に、オンラインとオフラインの両方で活動するReactコミュニティです。',
+  'オンラインでは、Discordを通じた情報交換や交流の場を提供し、オフラインではReactに関するイベントを開催します。',
+  '初心者から経験者まで、職種や技術力を問わず、誰でも気軽に参加できるのが特徴です。',
+  'Reactを学びたい人、新しいつながりを作りたい人、初めてコミュニティに参加する人も大歓迎です！',
+  '一緒にReactを楽しみましょう！',
+];
+
 export default async function HomePage() {
   return (
     <div>
       <title>{meta.title}</title>
       <div className="grid grid-rows-3 lg:grid-cols-3 lg:grid-flow-row gap-y-2 gap-x-8">
         <div className="lg:col-span-2 flex flex-col items-start justify-center">
-          <h1 className="text-4xl font-bold tracking-tight">We are React Tokyo Community</h1>
+          <h1 className="text-4xl font-bold tracking-tight">分からないを分かち合う、広げようReactの世界。</h1>
         </div>
         <div className="lg:row-span-3 flex items-center justify-center">
           <div className="w-40 lg:w-80 rounded-full bg-[#F45554]">
@@ -19,10 +27,9 @@ export default async function HomePage() {
         </div>
         <div className="lg:row-span-2 lg:col-span-2 flex flex-col items-start justify-center gap-8">
           <div>
-            <p>東京を中心としたReactのオンライン＆オフラインコミュニティです。</p>
-            <p>
-              オンラインでは、Discordを交流の場として活動し、オフラインでは、Reactのイベントを開催します。
-            </p>
+            {descriptions.map((description) => (
+              <p>{description}</p>
+            ))}
           </div>
           <div>
             <JoinDiscordServer />


### PR DESCRIPTION
### TASK
docs update: [キャッチコピーと該当説明文の差し替え](https://github.com/react-tokyo/tasks/issues/8)
---
### What I did
- docs: 説明文の差し替え
- style: タイトルとロゴ位置調整(モバイルのみ)
  - モバイル表示の最適化のため、タイトルとロゴの位置を変更しました。
 
---
### スクリーンショット
| SP| PC |
|----|----|
|![image](https://github.com/user-attachments/assets/240f1be5-0e8e-4ea3-83fc-1346de746277)|![image](https://github.com/user-attachments/assets/ec5dd2e2-577c-40b8-bcc1-4f5ef3ed66b4)|

---
### 補足
勝手にスタイルを調整しました。何か問題があれば、ご指導お願いします！