### PR TITLE
ヘッダーにDiscordの導線設置

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,11 +1,15 @@
 import { Link } from 'waku';
+import { JoinDiscordServer } from './joinDiscordServer';
 
 export const Header = () => {
   return (
-    <header className="flex items-center gap-4 p-6 lg:fixed lg:left-0 lg:top-0">
-      <h2 className="text-2xl font-bold tracking-tight">
+    <header className="flex items-center gap-4 p-6 w-full lg:fixed lg:left-0 lg:top-0">
+      <h2 className="text-2xl font-bold tracking-tight flex-grow">
         <Link to="/">React Tokyo</Link>
       </h2>
+      <div className="ml-auto">
+        <JoinDiscordServer />
+      </div>
     </header>
   );
 };

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -4,7 +4,7 @@ import { JoinDiscordServer } from './joinDiscordServer';
 export const Header = () => {
   return (
     <header className="flex items-center p-6 justify-between w-full lg:fixed lg:left-0 lg:top-0">
-      <h2 className="text-2xl font-bold tracking-tight">
+      <h2 className="text-xl sm:text-2xl font-bold tracking-tight">
         <Link to="/">React Tokyo</Link>
       </h2>
       <div>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -3,11 +3,11 @@ import { JoinDiscordServer } from './joinDiscordServer';
 
 export const Header = () => {
   return (
-    <header className="flex items-center gap-4 p-6 w-full lg:fixed lg:left-0 lg:top-0">
-      <h2 className="text-2xl font-bold tracking-tight flex-grow">
+    <header className="flex items-center p-6 justify-between w-full lg:fixed lg:left-0 lg:top-0">
+      <h2 className="text-2xl font-bold tracking-tight">
         <Link to="/">React Tokyo</Link>
       </h2>
-      <div className="ml-auto">
+      <div>
         <JoinDiscordServer />
       </div>
     </header>

--- a/src/components/joinDiscordServer.tsx
+++ b/src/components/joinDiscordServer.tsx
@@ -6,6 +6,6 @@ export const JoinDiscordServer = () => (
     rel="noreferrer"
   >
     <img className="h-5" src="/images/discord-logo-white.svg" alt="Discord logo" />
-    <span className="text-white">Join Discord Server</span>
+    <span className="text-white text-sm sm:text-base">Join Discord Server</span>
   </a>
 );


### PR DESCRIPTION
# Issue

[react-tokyo/tasks/#10](https://github.com/react-tokyo/tasks/issues/10)

# やったこと

ヘッダーにDiscordの導線設置しました。

# スクリーンショット

| SP | PC |
| ---- | ---- |
| <img width="287" alt="スクリーンショット 2024-12-16 22 52 17" src="https://github.com/user-attachments/assets/58aed337-0629-4339-8bb9-c2f4081bcee9" />| <img width="917" alt="スクリーンショット 2024-12-16 22 49 53" src="https://github.com/user-attachments/assets/2f6e2f78-e228-4b2a-ae0d-185cdc6c2291" />|
