### PR TITLE
トップのキャッチフレーズの折り返し調整

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,8 +21,8 @@ export default async function HomePage() {
           </div>
         </div>
         <div className="order-2 lg:order-1 lg:col-span-2 flex flex-col items-start justify-center py-6">
-          <h1 className="text-4xl font-bold tracking-tight">
-            分からないを分かち合う、広げようReactの世界。
+          <h1 className="text-2xl sm:text-4xl font-bold tracking-tight whitespace-pre-line sm:whitespace-normal">
+            {"分からないを分かち合う、\n広げようReactの世界。"}
           </h1>
         </div>
         <div className="order-3 lg:row-span-2 lg:col-span-2 flex flex-col items-start justify-center gap-8">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,7 +22,9 @@ export default async function HomePage() {
         </div>
         <div className="order-2 lg:order-1 lg:col-span-2 flex flex-col items-start justify-center py-6">
           <h1 className="text-2xl sm:text-4xl font-bold tracking-tight break-keep">
-            分からないを分かち合う、<wbr />広げようReactの世界。
+            分からないを分かち合う、
+            <wbr />
+            広げようReactの世界。
           </h1>
         </div>
         <div className="order-3 lg:row-span-2 lg:col-span-2 flex flex-col items-start justify-center gap-8">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,8 +21,8 @@ export default async function HomePage() {
           </div>
         </div>
         <div className="order-2 lg:order-1 lg:col-span-2 flex flex-col items-start justify-center py-6">
-          <h1 className="text-2xl sm:text-4xl font-bold tracking-tight whitespace-pre-line sm:whitespace-normal">
-            {"分からないを分かち合う、\n広げようReactの世界。"}
+          <h1 className="text-2xl sm:text-4xl font-bold tracking-tight break-keep">
+            分からないを分かち合う、<wbr />広げようReactの世界。
           </h1>
         </div>
         <div className="order-3 lg:row-span-2 lg:col-span-2 flex flex-col items-start justify-center gap-8">


### PR DESCRIPTION
### タスク

トップのキャッチフレーズの折り返し調整 [#24](https://github.com/react-tokyo/tasks/issues/24)

### やったこと

画面幅が小さい場合は、キャッチフレーズを折り返すようにして、文字サイズも調整しました。

### スクリーンショット

| SP | PC |
| ---- | ---- |
| <img width="486" alt="スクリーンショット 2024-12-19 21 46 53" src="https://github.com/user-attachments/assets/4a62a753-6156-421d-b8ae-04e74382b577" />| <img width="1472" alt="スクリーンショット 2024-12-19 21 47 15" src="https://github.com/user-attachments/assets/b8f89153-d0a7-4510-aef6-e9a5d476c451" />|