### PR TITLE
#28: トップのキャッチフレーズとFAQの左右の余白調整

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -11,7 +11,7 @@ export default async function RootLayout({ children }: RootLayoutProps) {
   return (
     <div className="font-['Nunito']">
       <Header />
-      <main className="m-6 flex justify-center *:min-h-64 *:min-w-64 lg:m-0 lg:min-h-svh lg:pb-20">
+      <main className="m-6 flex justify-center *:min-h-64 *:min-w-64 lg:my-0 lg:min-h-svh lg:pb-20">
         {children}
       </main>
       <Footer />


### PR DESCRIPTION
## issue
- https://github.com/react-tokyo/tasks/issues/28

## やったこと

- 左右のマージンを確保

## キャプチャ

![image](https://github.com/user-attachments/assets/9c2596d2-78e6-4981-bb6b-1fda762ccdf6)
