### PR TITLE
#32 スタイルが切り替わるタイミングを調整する

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,7 +21,7 @@ export default async function HomePage() {
           </div>
         </div>
         <div className="order-2 lg:order-1 lg:col-span-2 flex flex-col items-start justify-center py-6">
-          <h1 className="text-2xl sm:text-4xl font-bold tracking-tight break-keep">
+          <h1 className="text-2xl lg:text-4xl font-bold tracking-tight break-keep">
             分からないを分かち合う、
             <wbr />
             広げようReactの世界。


### PR DESCRIPTION
### タスク

スタイルが切り替わるタイミングを調整する https://github.com/react-tokyo/tasks/issues/32

### やったこと

issuesに記載されている以下で違和感ないと思ったので、以下の対応を行なっています。
もし他の場所でも気になるところがあれば対応するため、教えていただきたいです！

> https://github.com/dai-shi/react-tokyo-website/blob/main/src/pages/index.tsx#L24 のあたりの
sm => lg とかでいいかも

`wbr`の状態でテキストの改行としても違和感がないのと、`<span> + inline-block`だとスクリーンリーダーの対応が別途必要になる可能性があるため、`<span> + inline-block`の変更も行なっていません。

参考: https://zenn.dev/link/comments/01c74b1a0d2d6f

### スクリーンショット

| 375px | 1023px | 1024px | 1280px |
|--------|--------|--------|--------|
| <img width="521" alt="375" src="https://github.com/user-attachments/assets/f0dc89fc-2120-4e9f-a1c2-3f950633ae8f" /> | <img width="1022" alt="1023" src="https://github.com/user-attachments/assets/bf4c0129-eac5-467c-a817-58279327558c" /> | <img width="1022" alt="1024" src="https://github.com/user-attachments/assets/546d760f-8f8e-4fcf-b478-92169ce4e3d3" /> | <img width="1274" alt="1280" src="https://github.com/user-attachments/assets/53e6315a-9cbf-44c5-83fc-ea9b1bd3aa36" /> |

切り替えの1280pxから590pxまでの状態についても貼り付けておきます。

https://github.com/user-attachments/assets/8d59ecae-4749-4cf1-ab4d-91b20e5b331c