### PR TITLE
文字関連のデザイン微調整

### DIFF
--- a/src/components/faq.tsx
+++ b/src/components/faq.tsx
@@ -33,11 +33,11 @@ const faqs = [
 
 export const Faq = () => {
   return (
-    <div className="max-w-5xl space-y-4 lg:space-y-8">
+    <div className="space-y-4 lg:space-y-8">
       <h2 className="text-3xl font-bold">FAQ</h2>
       <dl className="space-y-6">
         {faqs.map((faq, index) => (
-          <div key={index} className="space-y-4 tracking-wider">
+          <div key={index} className="max-w-3xl space-y-4 tracking-wider">
             <dt className="grid grid-cols-[2rem_1fr] gap-1 text-xl font-semibold">
               <span className="justify-self-end text-[#F45554]">Q:</span>
               <span>{faq.question}</span>

--- a/src/components/faq.tsx
+++ b/src/components/faq.tsx
@@ -39,11 +39,20 @@ export const Faq = () => {
         {faqs.map((faq, index) => (
           <div key={index} className="max-w-3xl space-y-4 tracking-wider">
             <dt className="grid grid-cols-[2rem_1fr] gap-1 text-xl font-semibold">
-              <span className="justify-self-end text-[#F45554]">Q:</span>
+              <span
+                className="justify-self-end text-[#F45554]"
+                aria-hidden="true"
+              >
+                Q:
+              </span>
+              <span className="sr-only">質問</span>
               <span>{faq.question}</span>
             </dt>
             <dd className="grid grid-cols-[2rem_1fr] gap-1 text-pretty">
-              <span className="justify-self-end">A:</span>
+              <span className="justify-self-end" aria-hidden="true">
+                A:
+              </span>
+              <span className="sr-only">回答</span>
               <span>{faq.answer}</span>
             </dd>
           </div>

--- a/src/components/faq.tsx
+++ b/src/components/faq.tsx
@@ -38,10 +38,14 @@ export const Faq = () => {
       <dl className="space-y-6">
         {faqs.map((faq, index) => (
           <div key={index} className="space-y-4 tracking-wider">
-            <dt className="text-xl font-semibold">
-              <span className="text-[#F45554]">Q:</span> {faq.question}
+            <dt className="grid grid-cols-[2rem_1fr] gap-1 text-xl font-semibold">
+              <span className="justify-self-end text-[#F45554]">Q:</span>
+              <span>{faq.question}</span>
             </dt>
-            <dd className="text-pretty">A: {faq.answer}</dd>
+            <dd className="grid grid-cols-[2rem_1fr] gap-1 text-pretty">
+              <span className="justify-self-end">A:</span>
+              <span>{faq.answer}</span>
+            </dd>
           </div>
         ))}
       </dl>

--- a/src/components/faq.tsx
+++ b/src/components/faq.tsx
@@ -38,7 +38,7 @@ export const Faq = () => {
       <dl className="space-y-6">
         {faqs.map((faq, index) => (
           <div key={index} className="max-w-3xl space-y-4 tracking-wider">
-            <dt className="grid grid-cols-[2rem_1fr] gap-1 text-xl font-semibold">
+            <dt className="grid grid-cols-[1.5rem_1fr] gap-1 text-xl font-semibold">
               <span
                 className="justify-self-end text-[#F45554]"
                 aria-hidden="true"
@@ -48,7 +48,7 @@ export const Faq = () => {
               <span className="sr-only">質問</span>
               <span>{faq.question}</span>
             </dt>
-            <dd className="grid grid-cols-[2rem_1fr] gap-1 text-pretty">
+            <dd className="grid grid-cols-[1.5rem_1fr] gap-1 text-pretty">
               <span className="justify-self-end" aria-hidden="true">
                 A:
               </span>

--- a/src/pages.gen.ts
+++ b/src/pages.gen.ts
@@ -1,11 +1,11 @@
 import type { PathsForPages, GetConfigResponse } from 'waku/router';
 
-import type { getConfig as Root_getConfig } from './pages/_root';
 import type { getConfig as Index_getConfig } from './pages/index';
+import type { getConfig as Root_getConfig } from './pages/_root';
 
 type Page =
-  | ({ path: '/_root' } & GetConfigResponse<typeof Root_getConfig>)
-  | ({ path: '/' } & GetConfigResponse<typeof Index_getConfig>);
+  | ({ path: '/' } & GetConfigResponse<typeof Index_getConfig>)
+  | ({ path: '/_root' } & GetConfigResponse<typeof Root_getConfig>);
 
 declare module 'waku/router' {
   interface RouteConfig {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,7 @@ const descriptions = [
 
 export default async function HomePage() {
   return (
-    <div className="space-y-10 md:space-y-16 lg:pt-40">
+    <div className="space-y-10 text-gray-800 md:space-y-16 lg:pt-40">
       <Head />
       <div className="grid grid-rows-[auto_auto_auto] gap-x-8 gap-y-2 lg:grid-flow-row lg:grid-cols-3">
         <div className="order-1 flex items-center justify-center lg:order-2 lg:row-span-3">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,7 @@ const descriptions = [
 
 export default async function HomePage() {
   return (
-    <div className="space-y-10 text-gray-800 md:space-y-16 lg:pt-40">
+    <div className="space-y-10 text-gray-900 md:space-y-16 lg:pt-40">
       <Head />
       <div className="grid grid-rows-[auto_auto_auto] gap-x-8 gap-y-2 lg:grid-flow-row lg:grid-cols-3">
         <div className="order-1 flex items-center justify-center lg:order-2 lg:row-span-3">


### PR DESCRIPTION
- FAQ セクションの「Q, A」のあとに続く文字列の位置が揃うような「ぶら下げインデント」を実装しました
- 文章の幅が広すぎると読みづらいとされているので、狭めました
    - 35文字～40文字が最適とされている
        - [サイトの文章を読みやすくするためのWebタイポグラフィを考えてみる](https://www.remedia.co.jp/blog/posts/2023-05-web-typography/)
    - セクション自体の max-width は撤廃して、中にある各小項目としてのdivに max-width を設定しました。
        - （たぶんこうしたほうが拡張性がある…はず）
- 文字色が `#000` になっていたので、濃い灰色に変更しました。
    - [「ウェブサイトの本文色の黒は真っ黒（#000000）でないことが多い」って本当？検証してみた](https://www.evoworx.co.jp/blog/pureblack/)

| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/a461982c-ec41-491a-b0e9-2a838683be93) | ![image](https://github.com/user-attachments/assets/18b15fc6-4775-4240-87fc-ee06c1516804) | 
