### PR TITLE
fix card design

### DIFF
--- a/src/components/members/card.tsx
+++ b/src/components/members/card.tsx
@@ -15,7 +15,9 @@ export const Card = ({ profile }: { profile: Profile }) => {
         {profile.name}
       </h3>
       {profile.description && (
-        <p className="max-w-72 text-center break-keep">{profile.description}</p>
+        <p className="max-w-72 text-center leading-relaxed break-all">
+          {profile.description}
+        </p>
       )}
       {profile.xUrl && (
         <a

--- a/src/pages/members.tsx
+++ b/src/pages/members.tsx
@@ -13,7 +13,7 @@ export default async function MembersPage() {
         <h2 className="text-center text-4xl font-bold sm:text-5xl">
           Initiator
         </h2>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-[repeat(auto-fit,33%)] lg:justify-center">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-[repeat(auto-fit,33%)] lg:justify-center">
           {INITIATOR_PROFILES.map((profile) => (
             <Card key={profile.key} profile={profile} />
           ))}


### PR DESCRIPTION
## チェックリスト

- [x] 事前に[website実装プロジェクト](https://github.com/orgs/react-tokyo/projects/3)にタスクを作成して紐づけている

以下のタスクに対応します。
Close https://github.com/react-tokyo/tasks/issues/65
Close https://github.com/react-tokyo/tasks/issues/66

## 概要
モバイル環境でデザインが崩れる
- 410px以下でカードUI右側の余白が消える
- iPhone 14 plusで自己紹介文が右に突き抜ける

[プレビュー](https://react-tokyo-website-cordelia-preview.vercel.app/members)

#### 修正後
<img width="336" alt="スクリーンショット 2025-02-07 16 51 37" src="https://github.com/user-attachments/assets/e20a3339-e3d4-45b5-886d-6889e8bd18a7" />
<img width="336" alt="スクリーンショット 2025-02-07 16 07 30" src="https://github.com/user-attachments/assets/ab7b3fef-8da5-4d07-b01c-704e65754092" />

<br/>

文章は任意の箇所で折り返した方が見た目が良いので https://github.com/react-tokyo/tasks/issues/61 で対応予定。
