### PR TITLE
Update contact form

### DIFF
--- a/src/components/contact/contact.tsx
+++ b/src/components/contact/contact.tsx
@@ -1,75 +1,10 @@
-'use client';
+import { ContactForm } from './contactForm';
 
-import { useActionState } from 'react';
-import { ActionResponse } from './types';
-import { postContent } from './postContent';
-
-const initialState: ActionResponse = {
-  success: false,
-  message: '',
-};
 export const Contact = () => {
-  const [state, action, isPending] = useActionState(postContent, initialState);
-
   return (
     <section id="section" className="space-y-4 lg:space-y-8">
       <h2 className="text-3xl font-bold">Contact</h2>
-      <form action={action} className="relative grid max-w-[480px] gap-7">
-        <label htmlFor="name" className="block space-y-1">
-          お名前<span className="ml-2 text-sm text-[#F45554]">*必須</span>
-          <input
-            type="text"
-            name="name"
-            defaultValue={state.inputs?.name}
-            required
-            className="w-full rounded-md bg-slate-200 p-2 leading-6"
-          />
-          {state?.errors?.name && (
-            <p id="streetAddress-error" className="text-sm text-red-500">
-              {state.errors.name[0]}
-            </p>
-          )}
-        </label>
-        <label htmlFor="email" className="block space-y-1">
-          メールアドレス
-          <span className="ml-2 text-sm text-[#F45554]">*必須</span>
-          <input
-            type="email"
-            name="email"
-            defaultValue={state.inputs?.email}
-            required
-            className="w-full rounded-md bg-slate-200 p-2 leading-6"
-          />
-          {state?.errors?.email && (
-            <p id="streetAddress-error" className="text-sm text-red-500">
-              {state.errors.email[0]}
-            </p>
-          )}
-        </label>
-        <label htmlFor="contents" className="block space-y-1">
-          お問い合わせ内容
-          <span className="ml-2 text-sm text-[#F45554]">*必須</span>
-          <textarea
-            name="contents"
-            defaultValue={state.inputs?.contents}
-            required
-            className="min-h-[250px] w-full rounded-md bg-slate-200 p-2 leading-6"
-          ></textarea>
-          {state?.errors?.contents && (
-            <p id="streetAddress-error" className="text-sm text-red-500">
-              {state.errors.contents[0]}
-            </p>
-          )}
-        </label>
-        <button
-          type="submit"
-          disabled={isPending}
-          className="w-[150px] cursor-pointer rounded-full bg-[#5865F2] p-2 text-white"
-        >
-          {isPending ? '送信中...' : '送信'}
-        </button>
-        {state.message && <p className="text-lg">{state.message}</p>}
-      </form>
+      <ContactForm />
     </section>
   );
 };

--- a/src/components/contact/contactForm.tsx
+++ b/src/components/contact/contactForm.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useActionState } from 'react';
+import { ActionResponse } from './types';
+import { postContent } from './postContent';
+
+const initialState: ActionResponse = {
+  success: false,
+  message: '',
+};
+
+export const ContactForm = () => {
+  const [state, action, isPending] = useActionState(postContent, initialState);
+
+  return (
+    <form action={action} className="relative grid max-w-[480px] gap-7">
+      <label htmlFor="name" className="block space-y-1">
+        お名前<span className="ml-2 text-sm text-[#F45554]">*必須</span>
+        <input
+          type="text"
+          name="name"
+          defaultValue={state.inputs?.name}
+          required
+          className="w-full rounded-md bg-slate-200 p-2 leading-6"
+        />
+        {state?.errors?.name && (
+          <p id="streetAddress-error" className="text-sm text-red-500">
+            {state.errors.name[0]}
+          </p>
+        )}
+      </label>
+      <label htmlFor="email" className="block space-y-1">
+        メールアドレス
+        <span className="ml-2 text-sm text-[#F45554]">*必須</span>
+        <input
+          type="email"
+          name="email"
+          defaultValue={state.inputs?.email}
+          required
+          className="w-full rounded-md bg-slate-200 p-2 leading-6"
+        />
+        {state?.errors?.email && (
+          <p id="streetAddress-error" className="text-sm text-red-500">
+            {state.errors.email[0]}
+          </p>
+        )}
+      </label>
+      <label htmlFor="contents" className="block space-y-1">
+        お問い合わせ内容
+        <span className="ml-2 text-sm text-[#F45554]">*必須</span>
+        <textarea
+          name="contents"
+          defaultValue={state.inputs?.contents}
+          required
+          className="min-h-[250px] w-full rounded-md bg-slate-200 p-2 leading-6"
+        ></textarea>
+        {state?.errors?.contents && (
+          <p id="streetAddress-error" className="text-sm text-red-500">
+            {state.errors.contents[0]}
+          </p>
+        )}
+      </label>
+      <button
+        type="submit"
+        disabled={isPending}
+        className="w-[150px] cursor-pointer rounded-full bg-[#5865F2] p-2 text-white"
+      >
+        {isPending ? '送信中...' : '送信'}
+      </button>
+      {state.message && <p className="text-lg">{state.message}</p>}
+    </form>
+  );
+};

--- a/src/components/contact/contactForm.tsx
+++ b/src/components/contact/contactForm.tsx
@@ -6,7 +6,7 @@ import { postContent } from './postContent';
 
 const initialState: ActionResponse = {
   success: false,
-  message: '',
+  message: [''],
 };
 
 export const ContactForm = () => {

--- a/src/components/contact/contactForm.tsx
+++ b/src/components/contact/contactForm.tsx
@@ -3,6 +3,7 @@
 import { useActionState } from 'react';
 import { ActionResponse } from './types';
 import { postContent } from './postContent';
+import { renderTextContents } from '../lib/renderTextContents';
 
 const initialState: ActionResponse = {
   success: false,
@@ -15,7 +16,8 @@ export const ContactForm = () => {
   return (
     <form action={action} className="relative grid max-w-[480px] gap-7">
       <label htmlFor="name" className="block space-y-1">
-        お名前<span className="ml-2 text-sm text-[#F45554]">*必須</span>
+        お名前
+        <span className="ml-2 text-sm text-[#F45554]">*必須</span>
         <input
           type="text"
           name="name"
@@ -24,9 +26,7 @@ export const ContactForm = () => {
           className="w-full rounded-md bg-slate-200 p-2 leading-6"
         />
         {state?.errors?.name && (
-          <p id="streetAddress-error" className="text-sm text-red-500">
-            {state.errors.name[0]}
-          </p>
+          <p className="text-sm text-red-500">{state.errors.name[0]}</p>
         )}
       </label>
       <label htmlFor="email" className="block space-y-1">
@@ -40,9 +40,7 @@ export const ContactForm = () => {
           className="w-full rounded-md bg-slate-200 p-2 leading-6"
         />
         {state?.errors?.email && (
-          <p id="streetAddress-error" className="text-sm text-red-500">
-            {state.errors.email[0]}
-          </p>
+          <p className="text-sm text-red-500">{state.errors.email[0]}</p>
         )}
       </label>
       <label htmlFor="contents" className="block space-y-1">
@@ -55,9 +53,7 @@ export const ContactForm = () => {
           className="min-h-[250px] w-full rounded-md bg-slate-200 p-2 leading-6"
         ></textarea>
         {state?.errors?.contents && (
-          <p id="streetAddress-error" className="text-sm text-red-500">
-            {state.errors.contents[0]}
-          </p>
+          <p className="text-sm text-red-500">{state.errors.contents[0]}</p>
         )}
       </label>
       <button
@@ -67,7 +63,11 @@ export const ContactForm = () => {
       >
         {isPending ? '送信中...' : '送信'}
       </button>
-      {state.message && <p className="text-lg">{state.message}</p>}
+      {state.message && (
+        <p className="text-sm leading-relaxed">
+          {renderTextContents(state.message)}
+        </p>
+      )}
     </form>
   );
 };

--- a/src/components/contact/postContent.ts
+++ b/src/components/contact/postContent.ts
@@ -11,7 +11,9 @@ const contactFormSchema: ZodType<ContactFormData> = z.object({
  * お問い合わせを送信するGASのURL
  */
 const POST_URL =
-  'https://script.google.com/macros/s/AKfycbx_PhpMikSi0FTzbDfhcpGwLXdTvFD-iZw2lZ99wANS2_aF2RQc7jNE7hwEofp5pEdY/exec';
+  // 本番用。終わったらこれに戻す
+  // 'https://script.google.com/macros/s/AKfycbx_PhpMikSi0FTzbDfhcpGwLXdTvFD-iZw2lZ99wANS2_aF2RQc7jNE7hwEofp5pEdY/exec';
+  'https://script.google.com/macros/s/AKfycbxF3UnLUavr7Rd4YcUzuJBAThLNAqpO5f0VlmAn7aPQguOQHzh2Qnss3wXquLpRyOd5y/exec';
 const POST_INPUT_NAMES = ['name', 'email', 'contents'] as const;
 type FormNames = keyof ContactFormData;
 
@@ -36,7 +38,7 @@ export const postContent = async (
   if (!validatedData.success) {
     return {
       success: false,
-      message: '誤りのある箇所を修正してください。',
+      message: ['誤りのある箇所を修正してください。'],
       errors: validatedData.error.flatten().fieldErrors,
       inputs: rawData,
     };
@@ -80,8 +82,9 @@ export const postContent = async (
 
     return {
       success: true,
-      message:
+      message: [
         'お問い合わせありがとうございます🎉担当者よりご連絡いたしますので、しばらくお待ちください。',
+      ],
       inputs: blankData,
     };
   } catch {
@@ -98,8 +101,12 @@ export const postContent = async (
 const failureResult = (inputs: ContactFormData) => {
   return {
     success: false,
-    message:
-      'お問い合わせを送信できませんでした。申し訳ございませんがしばらく時間を置いてから再度お試しください。',
+    message: [
+      '何らかの問題が発生し、お問い合わせを送信できませんでした。',
+      '大変申し訳ございませんが、不具合報告をReact TokyoのDiscordサーバー内のご意見箱',
+      'もしくは公式アカウント(https://x.com/ReactTokyo)に',
+      'ご連絡くださいますようお願い申し上げます。',
+    ],
     inputs,
   };
 };

--- a/src/components/contact/postContent.ts
+++ b/src/components/contact/postContent.ts
@@ -11,9 +11,7 @@ const contactFormSchema: ZodType<ContactFormData> = z.object({
  * お問い合わせを送信するGASのURL
  */
 const POST_URL =
-  // 本番用。終わったらこれに戻す
-  // 'https://script.google.com/macros/s/AKfycbx_PhpMikSi0FTzbDfhcpGwLXdTvFD-iZw2lZ99wANS2_aF2RQc7jNE7hwEofp5pEdY/exec';
-  'https://script.google.com/macros/s/AKfycbxF3UnLUavr7Rd4YcUzuJBAThLNAqpO5f0VlmAn7aPQguOQHzh2Qnss3wXquLpRyOd5y/exec';
+  'https://script.google.com/macros/s/AKfycbx_PhpMikSi0FTzbDfhcpGwLXdTvFD-iZw2lZ99wANS2_aF2RQc7jNE7hwEofp5pEdY/exec';
 const POST_INPUT_NAMES = ['name', 'email', 'contents'] as const;
 type FormNames = keyof ContactFormData;
 
@@ -102,10 +100,7 @@ const failureResult = (inputs: ContactFormData) => {
   return {
     success: false,
     message: [
-      '何らかの問題が発生し、お問い合わせを送信できませんでした。',
-      '大変申し訳ございませんが、不具合報告を',
-      '[React Tokyo Discordサーバー内のご意見箱](https://discord.gg/5B9jYpABUy)もしくは[公式アカウント](https://x.com/ReactTokyo)まで',
-      'ご連絡くださいますようお願い申し上げます。',
+      '何らかの問題が発生し、お問い合わせを送信できませんでした。大変申し訳ございませんが、不具合報告をReact Tokyo Discordサーバー内の[ご意見箱](https://discord.gg/5B9jYpABUy)、もしくは[公式アカウント](https://x.com/ReactTokyo)までご連絡くださいますようお願い申し上げます。',
     ],
     inputs,
   };

--- a/src/components/contact/postContent.ts
+++ b/src/components/contact/postContent.ts
@@ -100,7 +100,7 @@ const failureResult = (inputs: ContactFormData) => {
   return {
     success: false,
     message: [
-      '何らかの問題が発生し、お問い合わせを送信できませんでした。大変申し訳ございませんが、不具合報告をReact Tokyo Discordサーバー内の[ご意見箱](https://discord.gg/5B9jYpABUy)、もしくは[公式アカウント](https://x.com/ReactTokyo)までご連絡くださいますようお願い申し上げます。',
+      '何らかの問題が発生し、お問い合わせを送信できませんでした。大変申し訳ございませんが、不具合報告をReact Tokyo Discordサーバー内の[ご意見箱](https://discord.gg/5B9jYpABUy)、もしくは[公式Xアカウント](https://x.com/ReactTokyo)までご連絡くださいますようお願い申し上げます。',
     ],
     inputs,
   };

--- a/src/components/contact/postContent.ts
+++ b/src/components/contact/postContent.ts
@@ -2,7 +2,7 @@ import { z, ZodType } from 'zod';
 import { ActionResponse, ContactFormData, GASResponse } from './types';
 
 const contactFormSchema: ZodType<ContactFormData> = z.object({
-  name: z.string().min(1, '名前または会社名を入力してください。'),
+  name: z.string().min(1, 'お名前または会社名を入力してください。'),
   email: z.string().min(1, 'メールアドレスを入力してください。'),
   contents: z.string().min(1, 'お問い合わせ内容を入力してください。'),
 });
@@ -103,8 +103,8 @@ const failureResult = (inputs: ContactFormData) => {
     success: false,
     message: [
       '何らかの問題が発生し、お問い合わせを送信できませんでした。',
-      '大変申し訳ございませんが、不具合報告をReact TokyoのDiscordサーバー内のご意見箱',
-      'もしくは公式アカウント(https://x.com/ReactTokyo)に',
+      '大変申し訳ございませんが、不具合報告を',
+      '[React Tokyo Discordサーバー内のご意見箱](https://discord.gg/5B9jYpABUy)もしくは[公式アカウント](https://x.com/ReactTokyo)まで',
       'ご連絡くださいますようお願い申し上げます。',
     ],
     inputs,

--- a/src/components/contact/types.ts
+++ b/src/components/contact/types.ts
@@ -19,7 +19,7 @@ export type GASResponse = {
  */
 export type ActionResponse = {
   success: boolean;
-  message: string;
+  message: string[];
   inputs?: ContactFormData;
   errors?: {
     [K in keyof ContactFormData]?: string[];

--- a/src/components/lib/renderTextContents.tsx
+++ b/src/components/lib/renderTextContents.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react/jsx-runtime';
+
 /**
  * 文字列の配列を受け取り、それぞれJSXに変換して返す
  *
@@ -17,11 +19,19 @@ export const renderTextContents = (messages: string[]) => {
 
     message.replace(linkPattern, (match, linkText, linkUrl, offset) => {
       if (lastIndex < offset) {
-        converted.push(<span>{message.slice(lastIndex, offset)}</span>);
+        converted.push(
+          <Fragment key={lastIndex}>
+            {message.slice(lastIndex, offset)}
+          </Fragment>,
+        );
       }
 
       converted.push(
-        <a className="underline" href={linkUrl}>
+        <a
+          key={linkUrl}
+          className="underline decoration-red-500 decoration-2"
+          href={linkUrl}
+        >
           {linkText}
         </a>,
       );
@@ -31,14 +41,16 @@ export const renderTextContents = (messages: string[]) => {
     });
 
     if (lastIndex < message.length) {
-      converted.push(<span>{message.slice(lastIndex)}</span>);
+      converted.push(
+        <Fragment key={lastIndex}>{message.slice(lastIndex)}</Fragment>,
+      );
     }
 
     return (
-      <>
-        <span>{converted}</span>
+      <span key={index}>
+        {converted}
         {index < messages.length - 1 && <br />}
-      </>
+      </span>
     );
   });
 };

--- a/src/components/lib/renderTextContents.tsx
+++ b/src/components/lib/renderTextContents.tsx
@@ -10,18 +10,18 @@ import { Fragment } from 'react/jsx-runtime';
  *
  * @param messages 文字列の配列
  */
-export const renderTextContents = (messages: string[]) => {
+export const renderTextContents = (contents: string[]) => {
   const linkPattern = /\[([^\]]+)\]\(([^)]+)\)/g;
 
-  return messages.map((message, index) => {
+  return contents.map((content, index) => {
     const converted = [];
     let lastIndex = 0;
 
-    message.replace(linkPattern, (match, linkText, linkUrl, offset) => {
+    content.replace(linkPattern, (match, linkText, linkUrl, offset) => {
       if (lastIndex < offset) {
         converted.push(
           <Fragment key={lastIndex}>
-            {message.slice(lastIndex, offset)}
+            {content.slice(lastIndex, offset)}
           </Fragment>,
         );
       }
@@ -40,16 +40,16 @@ export const renderTextContents = (messages: string[]) => {
       return match;
     });
 
-    if (lastIndex < message.length) {
+    if (lastIndex < content.length) {
       converted.push(
-        <Fragment key={lastIndex}>{message.slice(lastIndex)}</Fragment>,
+        <Fragment key={lastIndex}>{content.slice(lastIndex)}</Fragment>,
       );
     }
 
     return (
       <span key={index}>
         {converted}
-        {index < messages.length - 1 && <br />}
+        {index < contents.length - 1 && <br />}
       </span>
     );
   });

--- a/src/components/lib/renderTextContents.tsx
+++ b/src/components/lib/renderTextContents.tsx
@@ -27,11 +27,7 @@ export const renderTextContents = (contents: string[]) => {
       }
 
       converted.push(
-        <a
-          key={linkUrl}
-          className="underline decoration-red-500 decoration-2"
-          href={linkUrl}
-        >
+        <a key={linkUrl} className="underline" href={linkUrl}>
           {linkText}
         </a>,
       );

--- a/src/components/lib/renderTextContents.tsx
+++ b/src/components/lib/renderTextContents.tsx
@@ -1,0 +1,44 @@
+/**
+ * 文字列の配列を受け取り、それぞれJSXに変換して返す
+ *
+ * 配列の為、任意の箇所で改行できる。
+ * また、[リンク](https://example.com)形式の文字列があれば
+ * <a href='https://example.com'>リンク</a>
+ * に変換する
+ *
+ * @param messages 文字列の配列
+ */
+export const renderTextContents = (messages: string[]) => {
+  const linkPattern = /\[([^\]]+)\]\(([^)]+)\)/g;
+
+  return messages.map((message, index) => {
+    const converted = [];
+    let lastIndex = 0;
+
+    message.replace(linkPattern, (match, linkText, linkUrl, offset) => {
+      if (lastIndex < offset) {
+        converted.push(<span>{message.slice(lastIndex, offset)}</span>);
+      }
+
+      converted.push(
+        <a className="underline" href={linkUrl}>
+          {linkText}
+        </a>,
+      );
+
+      lastIndex = offset + match.length;
+      return match;
+    });
+
+    if (lastIndex < message.length) {
+      converted.push(<span>{message.slice(lastIndex)}</span>);
+    }
+
+    return (
+      <>
+        <span>{converted}</span>
+        {index < messages.length - 1 && <br />}
+      </>
+    );
+  });
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,8 +2,8 @@ import { JoinDiscordServer } from '../components/joinDiscordServer';
 import { Head } from '../components/head';
 import { Blogs } from '../components/blogs';
 import { Faq } from '../components/faq';
-import { Contact } from '../components/contact/contact';
 import { Descriptions } from '../components/descriptions';
+import { Contact } from '../components/contact/contact';
 
 export default async function HomePage() {
   return (

--- a/src/pages/sponsors.tsx
+++ b/src/pages/sponsors.tsx
@@ -5,7 +5,7 @@ import {
   ChartNoAxesCombined,
 } from 'lucide-react';
 
-import { Contact } from '../components/contact/contact';
+import { ContactForm } from '../components/contact/contactForm';
 
 export default async function SponsorsPage() {
   return (
@@ -331,7 +331,7 @@ export default async function SponsorsPage() {
           <br />
           ご興味のある企業様は、ぜひお気軽にDiscordまたはフォームからお問い合わせください。
         </p>
-        <Contact />
+        <ContactForm />
       </div>
     </section>
   );


### PR DESCRIPTION
## チェックリスト

- [x] 事前に[website実装プロジェクト](https://github.com/orgs/react-tokyo/projects/3)にタスクを作成して紐づけている

Close https://github.com/react-tokyo/tasks/issues/72
Close https://github.com/react-tokyo/tasks/issues/73

## 概要

- Contactをタイトルとフォーム本体に分離
- 問い合わせ時のエラーメッセージを変更。それに伴いメッセージ内にリンクが含まれる場合に表示できる関数を作りました。これはMembersページのメッセージにも使う想定です。

左がトップページ、右がスポンサーページ

<img width="400" alt="スクリーンショット 2025-02-28 22 57 48" src="https://github.com/user-attachments/assets/a40b154f-4d5d-43d5-95f0-61d89dd49669" /> <img width="400" alt="スクリーンショット 2025-02-28 22 58 05" src="https://github.com/user-attachments/assets/f83a2766-2e2d-4e8e-9f1c-ad6f857d053a" />

<br/>

エラーメッセージ
<img width="535" alt="スクリーンショット 2025-03-01 17 39 49" src="https://github.com/user-attachments/assets/7b83f427-dca4-45fe-a4ec-8ffdad1e6d4f" />

