### PR TITLE
トップページのBlogsに「もっと見る」のリンクを用意する

### DIFF
--- a/src/components/blogs/blogs.tsx
+++ b/src/components/blogs/blogs.tsx
@@ -1,4 +1,4 @@
-import { GATHERED_BLOGS } from '../blogs.gen';
+import { GATHERED_BLOGS } from '../../blogs.gen';
 
 export const Blogs = () => {
   return (

--- a/src/components/blogs/viewMoreLink.tsx
+++ b/src/components/blogs/viewMoreLink.tsx
@@ -1,3 +1,4 @@
+import { ChevronRight } from 'lucide-react';
 import { Link } from 'waku';
 
 export const ViewMoreLink = () => {
@@ -7,20 +8,7 @@ export const ViewMoreLink = () => {
       className="inline-flex items-center justify-center gap-2 rounded-full border border-gray-300 bg-white px-5 py-2 text-gray-700 hover:bg-gray-50"
     >
       <span>もっと見る</span>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="h-4 w-4"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M9 5l7 7-7 7"
-        />
-      </svg>
+      <ChevronRight />
     </Link>
   );
 };

--- a/src/components/blogs/viewMoreLink.tsx
+++ b/src/components/blogs/viewMoreLink.tsx
@@ -1,0 +1,26 @@
+import { Link } from 'waku';
+
+export const ViewMoreLink = () => {
+  return (
+    <Link
+      to="/blogs"
+      className="inline-flex items-center justify-center gap-2 rounded-full border border-gray-300 bg-white px-5 py-2 text-gray-700 hover:bg-gray-50"
+    >
+      <span>もっと見る</span>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="h-4 w-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M9 5l7 7-7 7"
+        />
+      </svg>
+    </Link>
+  );
+};

--- a/src/pages/blogs.tsx
+++ b/src/pages/blogs.tsx
@@ -1,4 +1,4 @@
-import { Blogs } from '../components/blogs';
+import { Blogs } from '../components/blogs/blogs';
 import { Head } from '../components/head';
 
 export default async function BlogsPage() {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,11 @@
 import { JoinDiscordServer } from '../components/joinDiscordServer';
 import { Head } from '../components/head';
 import { Link } from 'waku';
-import { Blogs } from '../components/blogs';
+import { Blogs } from '../components/blogs/blogs';
 import { Faq } from '../components/faq';
 import { Descriptions } from '../components/descriptions';
 import { Contact } from '../components/contact/contact';
+import { ViewMoreLink } from '../components/blogs/viewMoreLink';
 
 export default async function HomePage() {
   return (
@@ -35,6 +36,9 @@ export default async function HomePage() {
           <Link to="/blogs">BLOGS</Link>
         </h2>
         <Blogs />
+        <div className="mt-8 text-center">
+          <ViewMoreLink />
+        </div>
       </div>
       <Faq />
       <Contact />


### PR DESCRIPTION
## チェックリスト

- [x] 事前に[website実装プロジェクト](https://github.com/orgs/react-tokyo/projects/3)にタスクを作成して紐づけている

Close https://github.com/react-tokyo/tasks/issues/87

## 概要
- トップページでは最大4記事まで表示しないため、ブログの専用ページへの遷移先として「もっと見る」のリンクを追加しました
- 現状は「BLOGS」の見出しにのみリンクを設置していますが、それだけだと分かりにくいためです

### スクショ（PC）
<img width="1506" alt="スクリーンショット 2025-03-06 23 45 04" src="https://github.com/user-attachments/assets/7e19aee9-6d10-42a8-9bb1-371ac996e5d8" />

### スクショ（スマホ）
<img width="845" alt="スクリーンショット 2025-03-06 23 45 29" src="https://github.com/user-attachments/assets/1f4ad348-1296-4c28-9a4d-53f113dc727c" />