### PR TITLE
トップページの見出し「BLOGS」を「Blogs」に更新する 

### DIFF
--- a/src/pages/blogs.tsx
+++ b/src/pages/blogs.tsx
@@ -7,7 +7,7 @@ export default async function BlogsPage() {
       <Head title="Blogs - React Tokyo" />
       <div className="mx-auto max-w-[1300px]">
         <div className="space-y-4 lg:space-y-8">
-          <h1 className="text-3xl font-bold">BLOGS</h1>
+          <h1 className="text-3xl font-bold">Blogs</h1>
           <div className="space-y-4 lg:text-lg">
             <p>イベントレポートやZennのpublicationブログなど</p>
           </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -32,7 +32,7 @@ export default async function HomePage() {
       </div>
       <div className="space-y-4 lg:space-y-8">
         <h2 className="text-3xl font-bold">
-          <Link to="/blogs">BLOGS</Link>
+          <Link to="/blogs">Blogs</Link>
         </h2>
         <Blogs />
       </div>


### PR DESCRIPTION
## チェックリスト

- [x] 事前に[website実装プロジェクト](https://github.com/orgs/react-tokyo/projects/3)にタスクを作成して紐づけている

Close https://github.com/react-tokyo/tasks/issues/91#issue-2903017825

## 概要
トップページの他の見出し「Contact」のように先頭だけ大文字に統一しました

### トップページ
<img width="1421" alt="スクリーンショット 2025-03-07 22 51 06" src="https://github.com/user-attachments/assets/538915f3-0a6a-4513-93de-1f555ba541fe" />

### ブログページ
<img width="1421" alt="スクリーンショット 2025-03-07 22 51 56" src="https://github.com/user-attachments/assets/a8e40c53-e5a4-4810-a273-0ec817360620" />

こちらでレビューの指摘をいただいたため修正
- https://github.com/react-tokyo/tasks/issues/87#issuecomment-2704142862