### PR TITLE
表示するブログ記事を修正

### DIFF
--- a/scripts/generateGatheredBlogs.ts
+++ b/scripts/generateGatheredBlogs.ts
@@ -3,7 +3,16 @@ import ogs from 'open-graph-scraper';
 import prettier from 'prettier';
 
 const list = [
-  // 'https://zenn.dev/react_tokyo/articles/38a76f948c0d2f',
+  'https://zenn.dev/react_tokyo/articles/04d1af4b4a3abc',
+  'https://zenn.dev/react_tokyo/articles/f590adb2345c67',
+  'https://zenn.dev/react_tokyo/articles/fa97b98a527439',
+  'https://zenn.dev/react_tokyo/articles/77375d84125b76',
+  'https://zenn.dev/react_tokyo/articles/e487712a1629d7',
+  'https://zenn.dev/react_tokyo/articles/db90a5397364aa',
+  'https://zenn.dev/react_tokyo/articles/6aaea6220a2c3e',
+  'https://zenn.dev/react_tokyo/articles/37d79b1b2a7487',
+  'https://zenn.dev/react_tokyo/articles/ba82415acc2c04',
+  'https://zenn.dev/react_tokyo/articles/38a76f948c0d2f',
   'https://zenn.dev/tell_y/articles/f013a03370ee27',
   'https://zenn.dev/dai_shi/articles/9f2760086fb31a',
 ];

--- a/src/blogs.gen.ts
+++ b/src/blogs.gen.ts
@@ -1,5 +1,67 @@
 export const GATHERED_BLOGS = [
   {
+    url: 'https://zenn.dev/react_tokyo/articles/04d1af4b4a3abc',
+    title: 'React Tokyoコミュニティで地方開催を目指すワケ',
+    imageUrl:
+      'https://res.cloudinary.com/zenn/image/upload/s--Bi7EzB2u--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:React%2520Tokyo%25E3%2582%25B3%25E3%2583%259F%25E3%2583%25A5%25E3%2583%258B%25E3%2583%2586%25E3%2582%25A3%25E3%2581%25A7%25E5%259C%25B0%25E6%2596%25B9%25E9%2596%258B%25E5%2582%25AC%25E3%2582%2592%25E7%259B%25AE%25E6%258C%2587%25E3%2581%2599%25E3%2583%25AF%25E3%2582%25B1%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_34:daishi%2Cx_220%2Cy_108/bo_3px_solid_rgb:d6e3ed%2Cg_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzczM2MxYTQzYzYuanBlZw==%2Cr_20%2Cw_90%2Cx_92%2Cy_102/co_rgb:6e7b85%2Cg_south_west%2Cl_text:notosansjp-medium.otf_30:React%2520Tokyo%2Cx_220%2Cy_160/bo_4px_solid_white%2Cg_south_west%2Ch_50%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzcwZGNhM2E2Y2IuanBlZw==%2Cr_max%2Cw_50%2Cx_139%2Cy_84/v1627283836/default/og-base-w1200-v2.png',
+  },
+  {
+    url: 'https://zenn.dev/react_tokyo/articles/f590adb2345c67',
+    title:
+      'React Tokyo トレンドレポート #3 : TailwindCSS食わず嫌い集まれ！またはそういう人が身近にいる人',
+    imageUrl:
+      'https://res.cloudinary.com/zenn/image/upload/s--8we6jOfZ--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:React%2520Tokyo%2520%25E3%2583%2588%25E3%2583%25AC%25E3%2583%25B3%25E3%2583%2589%25E3%2583%25AC%25E3%2583%259D%25E3%2583%25BC%25E3%2583%2588%2520%25233%2520%253A%2520TailwindCSS%25E9%25A3%259F%25E3%2582%258F%25E3%2581%259A%25E5%25AB%258C%25E3%2581%2584%25E9%259B%2586%25E3%2581%25BE%25E3%2582%258C%25EF%25BC%2581%25E3%2581%25BE%25E3%2581%259F%25E3%2581%25AF%25E3%2581%259D%25E3%2581%2586%25E3%2581%2584%25E3%2581%2586%25E4%25BA%25BA%25E3%2581%258C%25E8%25BA%25AB%25E8%25BF%2591...%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_34:miwashutaro0611%2Cx_220%2Cy_108/bo_3px_solid_rgb:d6e3ed%2Cg_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzczM2MxYTQzYzYuanBlZw==%2Cr_20%2Cw_90%2Cx_92%2Cy_102/co_rgb:6e7b85%2Cg_south_west%2Cl_text:notosansjp-medium.otf_30:React%2520Tokyo%2Cx_220%2Cy_160/bo_4px_solid_white%2Cg_south_west%2Ch_50%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzBhZDA3YjNmMmIuanBlZw==%2Cr_max%2Cw_50%2Cx_139%2Cy_84/v1627283836/default/og-base-w1200-v2.png',
+  },
+  {
+    url: 'https://zenn.dev/react_tokyo/articles/fa97b98a527439',
+    title: 'React Tokyo ミートアップ #2 イベントレポート',
+    imageUrl:
+      'https://res.cloudinary.com/zenn/image/upload/s--CJo_29_7--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:React%2520Tokyo%2520%25E3%2583%259F%25E3%2583%25BC%25E3%2583%2588%25E3%2582%25A2%25E3%2583%2583%25E3%2583%2597%2520%25232%2520%25E3%2582%25A4%25E3%2583%2599%25E3%2583%25B3%25E3%2583%2588%25E3%2583%25AC%25E3%2583%259D%25E3%2583%25BC%25E3%2583%2588%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_34:spinrock%2Cx_220%2Cy_108/bo_3px_solid_rgb:d6e3ed%2Cg_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzczM2MxYTQzYzYuanBlZw==%2Cr_20%2Cw_90%2Cx_92%2Cy_102/co_rgb:6e7b85%2Cg_south_west%2Cl_text:notosansjp-medium.otf_30:React%2520Tokyo%2Cx_220%2Cy_160/bo_4px_solid_white%2Cg_south_west%2Ch_50%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzhjMWFjM2U1OGIuanBlZw==%2Cr_max%2Cw_50%2Cx_139%2Cy_84/v1627283836/default/og-base-w1200-v2.png',
+  },
+  {
+    url: 'https://zenn.dev/react_tokyo/articles/77375d84125b76',
+    title: 'React Tokyo トレンドレポート #2 : 初めてReactを学ぶ教材',
+    imageUrl:
+      'https://res.cloudinary.com/zenn/image/upload/s--FgzgO846--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:React%2520Tokyo%2520%25E3%2583%2588%25E3%2583%25AC%25E3%2583%25B3%25E3%2583%2589%25E3%2583%25AC%25E3%2583%259D%25E3%2583%25BC%25E3%2583%2588%2520%25232%2520%253A%2520%25E5%2588%259D%25E3%2582%2581%25E3%2581%25A6React%25E3%2582%2592%25E5%25AD%25A6%25E3%2581%25B6%25E6%2595%2599%25E6%259D%2590%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_34:%25E3%2582%25BF%25E3%2583%25A0%2540%25E3%2582%25A8%25E3%2583%25B3%25E3%2582%25B8%25E3%2583%258B%25E3%2582%25A2%2Cx_220%2Cy_108/bo_3px_solid_rgb:d6e3ed%2Cg_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzczM2MxYTQzYzYuanBlZw==%2Cr_20%2Cw_90%2Cx_92%2Cy_102/co_rgb:6e7b85%2Cg_south_west%2Cl_text:notosansjp-medium.otf_30:React%2520Tokyo%2Cx_220%2Cy_160/bo_4px_solid_white%2Cg_south_west%2Ch_50%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyL2JmNzdjNGQ0YTAuanBlZw==%2Cr_max%2Cw_50%2Cx_139%2Cy_84/v1627283836/default/og-base-w1200-v2.png',
+  },
+  {
+    url: 'https://zenn.dev/react_tokyo/articles/e487712a1629d7',
+    title: 'React Tokyo ミートアップ #1  イベントレポート',
+    imageUrl:
+      'https://res.cloudinary.com/zenn/image/upload/s--5bJMcsMk--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:React%2520Tokyo%2520%25E3%2583%259F%25E3%2583%25BC%25E3%2583%2588%25E3%2582%25A2%25E3%2583%2583%25E3%2583%2597%2520%25231%2520%2520%25E3%2582%25A4%25E3%2583%2599%25E3%2583%25B3%25E3%2583%2588%25E3%2583%25AC%25E3%2583%259D%25E3%2583%25BC%25E3%2583%2588%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_34:cordelia%2Cx_220%2Cy_108/bo_3px_solid_rgb:d6e3ed%2Cg_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzczM2MxYTQzYzYuanBlZw==%2Cr_20%2Cw_90%2Cx_92%2Cy_102/co_rgb:6e7b85%2Cg_south_west%2Cl_text:notosansjp-medium.otf_30:React%2520Tokyo%2Cx_220%2Cy_160/bo_4px_solid_white%2Cg_south_west%2Ch_50%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzM0YmFmZWVjNTguanBlZw==%2Cr_max%2Cw_50%2Cx_139%2Cy_84/v1627283836/default/og-base-w1200-v2.png',
+  },
+  {
+    url: 'https://zenn.dev/react_tokyo/articles/db90a5397364aa',
+    title: 'React Tokyo トレンドレポート : <ViewTransition> Component',
+    imageUrl:
+      'https://res.cloudinary.com/zenn/image/upload/s--FFjcRWI0--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:React%2520Tokyo%2520%25E3%2583%2588%25E3%2583%25AC%25E3%2583%25B3%25E3%2583%2589%25E3%2583%25AC%25E3%2583%259D%25E3%2583%25BC%25E3%2583%2588%2520%253A%2520%253CViewTransition%253E%2520Component%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_34:cordelia%2Cx_220%2Cy_108/bo_3px_solid_rgb:d6e3ed%2Cg_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzczM2MxYTQzYzYuanBlZw==%2Cr_20%2Cw_90%2Cx_92%2Cy_102/co_rgb:6e7b85%2Cg_south_west%2Cl_text:notosansjp-medium.otf_30:React%2520Tokyo%2Cx_220%2Cy_160/bo_4px_solid_white%2Cg_south_west%2Ch_50%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzM0YmFmZWVjNTguanBlZw==%2Cr_max%2Cw_50%2Cx_139%2Cy_84/v1627283836/default/og-base-w1200-v2.png',
+  },
+  {
+    url: 'https://zenn.dev/react_tokyo/articles/6aaea6220a2c3e',
+    title: 'React TokyoコミュニティでのDiscordチャンネルの利用方法',
+    imageUrl:
+      'https://res.cloudinary.com/zenn/image/upload/s--UE15YsQk--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:React%2520Tokyo%25E3%2582%25B3%25E3%2583%259F%25E3%2583%25A5%25E3%2583%258B%25E3%2583%2586%25E3%2582%25A3%25E3%2581%25A7%25E3%2581%25AEDiscord%25E3%2583%2581%25E3%2583%25A3%25E3%2583%25B3%25E3%2583%258D%25E3%2583%25AB%25E3%2581%25AE%25E5%2588%25A9%25E7%2594%25A8%25E6%2596%25B9%25E6%25B3%2595%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_34:daishi%2Cx_220%2Cy_108/bo_3px_solid_rgb:d6e3ed%2Cg_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzczM2MxYTQzYzYuanBlZw==%2Cr_20%2Cw_90%2Cx_92%2Cy_102/co_rgb:6e7b85%2Cg_south_west%2Cl_text:notosansjp-medium.otf_30:React%2520Tokyo%2Cx_220%2Cy_160/bo_4px_solid_white%2Cg_south_west%2Ch_50%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzcwZGNhM2E2Y2IuanBlZw==%2Cr_max%2Cw_50%2Cx_139%2Cy_84/v1627283836/default/og-base-w1200-v2.png',
+  },
+  {
+    url: 'https://zenn.dev/react_tokyo/articles/37d79b1b2a7487',
+    title: 'React FrameworkのWakuを触ってみてワクワクした話⛩️',
+    imageUrl:
+      'https://res.cloudinary.com/zenn/image/upload/s--NoKVLnHo--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:React%2520Framework%25E3%2581%25AEWaku%25E3%2582%2592%25E8%25A7%25A6%25E3%2581%25A3%25E3%2581%25A6%25E3%2581%25BF%25E3%2581%25A6%25E3%2583%25AF%25E3%2582%25AF%25E3%2583%25AF%25E3%2582%25AF%25E3%2581%2597%25E3%2581%259F%25E8%25A9%25B1%2520%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_34:cordelia%2Cx_220%2Cy_108/bo_3px_solid_rgb:d6e3ed%2Cg_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzczM2MxYTQzYzYuanBlZw==%2Cr_20%2Cw_90%2Cx_92%2Cy_102/co_rgb:6e7b85%2Cg_south_west%2Cl_text:notosansjp-medium.otf_30:React%2520Tokyo%2Cx_220%2Cy_160/bo_4px_solid_white%2Cg_south_west%2Ch_50%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzM0YmFmZWVjNTguanBlZw==%2Cr_max%2Cw_50%2Cx_139%2Cy_84/v1627283836/default/og-base-w1200-v2.png',
+  },
+  {
+    url: 'https://zenn.dev/react_tokyo/articles/ba82415acc2c04',
+    title: '駆け出しエンジニアだからこそコミュニティに飛び込んでみよう！',
+    imageUrl:
+      'https://res.cloudinary.com/zenn/image/upload/s--41bgdk6q--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:%25E9%25A7%2586%25E3%2581%2591%25E5%2587%25BA%25E3%2581%2597%25E3%2582%25A8%25E3%2583%25B3%25E3%2582%25B8%25E3%2583%258B%25E3%2582%25A2%25E3%2581%25A0%25E3%2581%258B%25E3%2582%2589%25E3%2581%2593%25E3%2581%259D%25E3%2582%25B3%25E3%2583%259F%25E3%2583%25A5%25E3%2583%258B%25E3%2583%2586%25E3%2582%25A3%25E3%2581%25AB%25E9%25A3%259B%25E3%2581%25B3%25E8%25BE%25BC%25E3%2582%2593%25E3%2581%25A7%25E3%2581%25BF%25E3%2582%2588%25E3%2581%2586%25EF%25BC%2581%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_34:Yusuke%2520Kikuta%2Cx_220%2Cy_108/bo_3px_solid_rgb:d6e3ed%2Cg_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzczM2MxYTQzYzYuanBlZw==%2Cr_20%2Cw_90%2Cx_92%2Cy_102/co_rgb:6e7b85%2Cg_south_west%2Cl_text:notosansjp-medium.otf_30:React%2520Tokyo%2Cx_220%2Cy_160/bo_4px_solid_white%2Cg_south_west%2Ch_50%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzAxNzNiNGMzZDEuanBlZw==%2Cr_max%2Cw_50%2Cx_139%2Cy_84/v1627283836/default/og-base-w1200-v2.png',
+  },
+  {
+    url: 'https://zenn.dev/react_tokyo/articles/38a76f948c0d2f',
+    title:
+      '祝・React Tokyo始動〜コニュニティ発足から公式サイトリリースまでの軌跡〜',
+    imageUrl:
+      'https://res.cloudinary.com/zenn/image/upload/s--kYr6LDGP--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:%25E7%25A5%259D%25E3%2583%25BBReact%2520Tokyo%25E5%25A7%258B%25E5%258B%2595%25E3%2580%259C%25E3%2582%25B3%25E3%2583%258B%25E3%2583%25A5%25E3%2583%258B%25E3%2583%2586%25E3%2582%25A3%25E7%2599%25BA%25E8%25B6%25B3%25E3%2581%258B%25E3%2582%2589%25E5%2585%25AC%25E5%25BC%258F%25E3%2582%25B5%25E3%2582%25A4%25E3%2583%2588%25E3%2583%25AA%25E3%2583%25AA%25E3%2583%25BC%25E3%2582%25B9%25E3%2581%25BE%25E3%2581%25A7%25E3%2581%25AE%25E8%25BB%258C%25E8%25B7%25A1%25E3%2580%259C%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_34:hakushun%2Cx_220%2Cy_108/bo_3px_solid_rgb:d6e3ed%2Cg_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzczM2MxYTQzYzYuanBlZw==%2Cr_20%2Cw_90%2Cx_92%2Cy_102/co_rgb:6e7b85%2Cg_south_west%2Cl_text:notosansjp-medium.otf_30:React%2520Tokyo%2Cx_220%2Cy_160/bo_4px_solid_white%2Cg_south_west%2Ch_50%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzRhZGZlNDQwMWQuanBlZw==%2Cr_max%2Cw_50%2Cx_139%2Cy_84/v1627283836/default/og-base-w1200-v2.png',
+  },
+  {
     url: 'https://zenn.dev/tell_y/articles/f013a03370ee27',
     title: 'Re: React Tokyoというコミュニティを作ろうと思ったワケ',
     imageUrl:

--- a/src/components/blogs/blogs.tsx
+++ b/src/components/blogs/blogs.tsx
@@ -8,7 +8,7 @@ type BlogsProps = {
 
 export const Blogs = ({ displayLimit = GATHERED_BLOGS.length }: BlogsProps) => {
   return (
-    <ul className="grid grid-cols-1 place-items-stretch justify-items-center gap-4 md:grid-cols-2">
+    <ul className="m-auto grid w-fit grid-cols-1 place-items-stretch justify-items-center gap-4 md:grid-cols-2">
       {GATHERED_BLOGS.slice(0, displayLimit).map((blog) => (
         <li key={blog.url} className="max-w-lg">
           <a href={blog.url} target="_blank" rel="noreferrer">

--- a/src/components/blogs/blogs.tsx
+++ b/src/components/blogs/blogs.tsx
@@ -1,9 +1,15 @@
 import { GATHERED_BLOGS } from '../../blogs.gen';
 
-export const Blogs = () => {
+export const DISPLAY_BLOGS_LIMIT = 4;
+
+type BlogsProps = {
+  displayLimit?: number;
+};
+
+export const Blogs = ({ displayLimit = GATHERED_BLOGS.length }: BlogsProps) => {
   return (
     <ul className="grid grid-cols-1 place-items-stretch justify-items-center gap-4 md:grid-cols-2">
-      {GATHERED_BLOGS.map((blog) => (
+      {GATHERED_BLOGS.slice(0, displayLimit).map((blog) => (
         <li key={blog.url} className="max-w-lg">
           <a href={blog.url} target="_blank" rel="noreferrer">
             <img src={blog.imageUrl} alt={blog.title} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import { JoinDiscordServer } from '../components/join-discord-server';
 import { Head } from '../components/head';
 import { Link } from 'waku';
-import { Blogs } from '../components/blogs/blogs';
+import { Blogs, DISPLAY_BLOGS_LIMIT } from '../components/blogs/blogs';
 import { Faq } from '../components/faq';
 import { Descriptions } from '../components/descriptions';
 import { Contact } from '../components/contact/contact';
@@ -35,7 +35,7 @@ export default async function HomePage() {
         <h2 className="text-3xl font-bold">
           <Link to="/blogs">Blogs</Link>
         </h2>
-        <Blogs />
+        <Blogs displayLimit={DISPLAY_BLOGS_LIMIT} />
         <div className="mt-8 text-center">
           <ViewMoreLink />
         </div>


### PR DESCRIPTION
## チェックリスト

- [x] 事前に[website実装プロジェクト](https://github.com/orgs/react-tokyo/projects/3)にタスクを作成して紐づけている

Close https://github.com/react-tokyo/tasks/issues/88
Close https://github.com/react-tokyo/tasks/issues/96

## 概要
上記2つのタスクはまとめても問題ないと判断したので1つのPRにしてます。

- 表示するブログ記事のデータを追加
- トップページには最新4記事まで表示
- `Blogs`コンポーネントを、今後のフィルタリング機能に対応しやすいようpropsを受け取る形に変更
- cssスタイルを若干変更
